### PR TITLE
Fix leave request email templates

### DIFF
--- a/application/views/emails/de/request.php
+++ b/application/views/emails/de/request.php
@@ -10,7 +10,7 @@
 <html lang="en">
     <body>
         <h3>{Title}</h3>
-        {Firstname} {Lastname} beantragt Urlaub. Hierzu die <a href="{BaseUrl}leaves/{LeaveId}">Details</a> :
+        {Firstname} {Lastname} beantragt Urlaub. Hierzu die <a href="{BaseUrl}leaves/requests/{LeaveId}">Details</a> :
         <table border="0">
             <tr>
                 <td>Von &nbsp;</td><td>{StartDate}&nbsp;({StartDateType})</td>

--- a/application/views/emails/en/request.php
+++ b/application/views/emails/en/request.php
@@ -20,7 +20,7 @@
     </head>
     <body>
         <h3>{Title}</h3>
-        {Firstname} {Lastname} requested time off. See the <a href="{BaseUrl}leaves/{LeaveId}">details</a> below:<br />
+        {Firstname} {Lastname} requested time off. See the <a href="{BaseUrl}leaves/requests/{LeaveId}">details</a> below:<br />
         <table border="0">
             <tr>
                 <td>From &nbsp;</td><td>{StartDate}&nbsp;({StartDateType})</td>

--- a/application/views/emails/es/request.php
+++ b/application/views/emails/es/request.php
@@ -10,7 +10,7 @@
 <html lang="es">
     <body>
         <h3>{Title}</h3>
-        {Firstname} {Lastname} solicitud de una licencia. A continuación, el <a href="{BaseUrl}leaves/{LeaveId}">detalle</a> :
+        {Firstname} {Lastname} solicitud de una licencia. A continuación, el <a href="{BaseUrl}leaves/requests/{LeaveId}">detalle</a> :
         <table border="0">
             <tr>
                 <td>Desde &nbsp;</td><td>{StartDate}&nbsp;({StartDateType})</td>

--- a/application/views/emails/fa/request.php
+++ b/application/views/emails/fa/request.php
@@ -20,7 +20,7 @@
     </head>
     <body>
         <h3>{Title}</h3>
-        {Firstname} {Lastname} درخواست مرخصی داده است. جزئیات در <a href="{BaseUrl}leaves/{LeaveId}">اینجا</a> :
+        {Firstname} {Lastname} درخواست مرخصی داده است. جزئیات در <a href="{BaseUrl}leaves/requests/{LeaveId}">اینجا</a> :
         <table border="0">
             <tr>
                 <td>از &nbsp;</td><td>{StartDate}&nbsp;({StartDateType})</td>

--- a/application/views/emails/fr/request.php
+++ b/application/views/emails/fr/request.php
@@ -20,7 +20,7 @@
     </head>
     <body>
         <h3>{Title}</h3>
-        <p>{Firstname} {Lastname} vous soumet une demande d'absence. Voici les <a href="{BaseUrl}leaves/{LeaveId}">détails</a> :</p>
+        <p>{Firstname} {Lastname} vous soumet une demande d'absence. Voici les <a href="{BaseUrl}leaves/requests/{LeaveId}">détails</a> :</p>
         <table>
             <tr>
                 <td>Du &nbsp;</td><td>{StartDate}&nbsp;({StartDateType})</td>

--- a/application/views/emails/it/request.php
+++ b/application/views/emails/it/request.php
@@ -20,7 +20,7 @@
     </head>
     <body>
         <h3>{Title}</h3>
-        {Firstname} {Lastname} richiede un congedo. Qui di seguito <a href="{BaseUrl}leaves/{LeaveId}">i dettagli</a>:
+        {Firstname} {Lastname} richiede un congedo. Qui di seguito <a href="{BaseUrl}leaves/requests/{LeaveId}">i dettagli</a>:
         <table border="0">
             <tr>
                 <td>Da &nbsp;</td><td>{StartDate}&nbsp;({StartDateType})</td>

--- a/application/views/emails/km/request.php
+++ b/application/views/emails/km/request.php
@@ -14,7 +14,7 @@
     </head>
     <body>
         <h3>{Title}</h3>
-        {Firstname} {Lastname} <a href="{BaseUrl}leaves/{LeaveId}">ស្នើសុំចាកចេញមួយខាងក្រោមសេចក្ដីលម្អិត</a> :
+        {Firstname} {Lastname} <a href="{BaseUrl}leaves/requests/{LeaveId}">ស្នើសុំចាកចេញមួយខាងក្រោមសេចក្ដីលម្អិត</a> :
         <table border="0">
             <tr>
                 <td>មកពី &nbsp;</td><td>{StartDate}&nbsp;({StartDateType})</td>

--- a/application/views/emails/nl/request.php
+++ b/application/views/emails/nl/request.php
@@ -14,7 +14,7 @@
     </head>
     <body>
         <h3>{Title}</h3>
-        Afwezigheidsverzoek van {Firstname} {Lastname}. Hieronder de <a href="{BaseUrl}leaves/{LeaveId}">details</a> :
+        Afwezigheidsverzoek van {Firstname} {Lastname}. Hieronder de <a href="{BaseUrl}leaves/requests/{LeaveId}">details</a> :
         <table border="0">
             <tr>
                 <td>Van &nbsp;</td><td>{StartDate}&nbsp;({StartDateType})</td>

--- a/application/views/emails/pl/request.php
+++ b/application/views/emails/pl/request.php
@@ -20,7 +20,7 @@
     </head>
     <body>
         <h3>{Title}</h3>
-        {Firstname} {Lastname} prosi o urlop. Poniżej, <a href="{BaseUrl}leaves/{LeaveId}">detale</a> :
+        {Firstname} {Lastname} prosi o urlop. Poniżej, <a href="{BaseUrl}leaves/requests/{LeaveId}">detale</a> :
         <table border="0">
             <tr>
                 <td>Od &nbsp;</td><td>{StartDate}&nbsp;({StartDateType})</td>

--- a/application/views/emails/ru/request.php
+++ b/application/views/emails/ru/request.php
@@ -20,7 +20,7 @@
     </head>
     <body>
         <h3>{Title}</h3>
-        {Firstname} {Lastname} отправил заявление на отпуск. <a href="{BaseUrl}leaves/{LeaveId}">Детали</a> ниже:
+        {Firstname} {Lastname} отправил заявление на отпуск. <a href="{BaseUrl}leaves/requests/{LeaveId}">Детали</a> ниже:
         <table border="0">
             <tr>
                 <td>От &nbsp;</td><td>{StartDate}&nbsp;({StartDateType})</td>

--- a/application/views/emails/tr/request.php
+++ b/application/views/emails/tr/request.php
@@ -20,7 +20,7 @@
     </head>
     <body>
         <h3>{Title}</h3>
-        {Firstname} {Lastname} requested time off. See the <a href="{BaseUrl}leaves/{LeaveId}">details</a> below:<br />
+        {Firstname} {Lastname} requested time off. See the <a href="{BaseUrl}leaves/requests/{LeaveId}">details</a> below:<br />
         <table border="0">
             <tr>
                 <td>From &nbsp;</td><td>{StartDate}&nbsp;({StartDateType})</td>

--- a/application/views/emails/uk/request.php
+++ b/application/views/emails/uk/request.php
@@ -20,7 +20,7 @@
     </head>
     <body>
         <h3>{Title}</h3>
-        {Firstname} {Lastname} відправив заяву на відпустку. <a href="{BaseUrl}leaves/{LeaveId}">Подробиці</a> нижче:
+        {Firstname} {Lastname} відправив заяву на відпустку. <a href="{BaseUrl}leaves/requests/{LeaveId}">Подробиці</a> нижче:
         <table border="0">
             <tr>
                 <td>Від &nbsp;</td><td>{StartDate}&nbsp;({StartDateType})</td>

--- a/application/views/emails/vi/request.php
+++ b/application/views/emails/vi/request.php
@@ -20,7 +20,7 @@
     </head>
     <body>
         <h3>{Title}</h3>
-        {Firstname} {Lastname} đã yêu cầu nghỉ phép. <a href="{BaseUrl}leaves/{LeaveId}">Xem chi tiết</a> bên dưới:<br />
+        {Firstname} {Lastname} đã yêu cầu nghỉ phép. <a href="{BaseUrl}leaves/requests/{LeaveId}">Xem chi tiết</a> bên dưới:<br />
         <table border="0">
             <tr>
                 <td>Từ</td><td>{StartDate}&nbsp;({StartDateType})</td>

--- a/application/views/emails/zh/request.php
+++ b/application/views/emails/zh/request.php
@@ -20,7 +20,7 @@
     </head>
     <body>
         <h3>{Title}</h3>
-        {Firstname} {Lastname} requested time off. See the <a href="{BaseUrl}leaves/{LeaveId}">details</a> below:<br />
+        {Firstname} {Lastname} requested time off. See the <a href="{BaseUrl}leaves/requests/{LeaveId}">details</a> below:<br />
         <table border="0">
             <tr>
                 <td>From &nbsp;</td><td>{StartDate}&nbsp;({StartDateType})</td>


### PR DESCRIPTION
Hi Benjamin,
I remake a new pull request for the leave request email templates:
- Email view missing `/requests` in the `detail` link.

![zalo_screenshot_28_6_2016_1053555](https://cloud.githubusercontent.com/assets/2689136/16403393/e24f9a7c-3d1e-11e6-96da-ba2759efce3a.png)
