### PR TITLE
testmail.php changed `PHPMailer` to lowercase

### DIFF
--- a/testmail.php
+++ b/testmail.php
@@ -54,7 +54,7 @@ if (EMAIL_ADDRESS == '') {
         include $pathConfigFile;
         try {
             //Include shipped PHPMailer library
-            $phpmailerLib = realpath(join(DIRECTORY_SEPARATOR, array('application', 'third_party', 'PHPMailer', 'PHPMailerAutoload.php')));
+            $phpmailerLib = realpath(join(DIRECTORY_SEPARATOR, array('application', 'third_party', 'phpmailer', 'PHPMailerAutoload.php')));
             require_once $phpmailerLib;
             $mail = new PHPMailer(true); //true => throw exceptions on error
             $mail->SMTPDebug = 2;     //Debug informations


### PR DESCRIPTION
related issue : #232 

`testmail.php` currently uses `PHPMailer` as an argument at line `57` which doesn't work on file systems with case-sensitive file and directory names.
 This should therefore be changed to `phpmailer`.
