### PR TITLE
Bug accessing yearly calendar under certain conditions (permission problem)

### DIFF
--- a/application/controllers/Calendar.php
+++ b/application/controllers/Calendar.php
@@ -33,7 +33,7 @@ class Calendar extends CI_Controller {
     public function year($employee = 0, $year = 0) {
         setUserContext($this);
         $this->lang->load('calendar', $this->language);
-        if ($employee == 0) {
+        if ($employee == 0 || $employee == $this->user_id) {
             $this->auth->checkIfOperationIsAllowed('individual_calendar');
         } else {
             $this->auth->checkIfOperationIsAllowed('organization_calendar');


### PR DESCRIPTION

See ticket #266

1) In config.php the following has been set:

```
$config['hide_global_cals_to_users'] = TRUE;
```
2) The user that access is not manager or HR manager

3) And you try to access:

Calendar->Yearly Calendar
And then click no the next year, or previous year.


The effect is that you get an error like the following:

```
ERROR - 2018-11-20 14:25:17 --> User #92 illegally tried to access to organization_calendar
```

This seems to be because the initial URL is:

GET https://vacaciones.qindel.com/calendar/year

and the next url is:

GET https://vacaciones.qindel.com/calendar/year/92/2019

(See application/views/calendar/year.php)

Which makes that the value $employee is non 0, but matches the current user id.