### PR TITLE
Allow to show info of non direct reports per manager #264 #265

### DIFF
--- a/application/config/config.php
+++ b/application/config/config.php
@@ -486,7 +486,7 @@ $config['fonts'] =
 //____________________________________________________________________________
 // Hide/Disable features
 $config['disable_overtime'] = FALSE; //Set this value to TRUE if you want to hide the menu entries related to overtime
-$config['hide_global_cals_to_users'] = TRUE; //Set this value to TRUE if you want to hide global calendars (global/tabular) to users
+$config['hide_global_cals_to_users'] = FALSE; //Set this value to TRUE if you want to hide global calendars (global/tabular) to users
 $config['disable_department_calendar'] = FALSE; //Set this value to TRUE in order to disable the menu entry 'departement'
 $config['disable_workmates_calendar'] = FALSE; //Set this value to TRUE in order to disable the menu entry 'my workmates'
 

--- a/application/config/config.php
+++ b/application/config/config.php
@@ -452,6 +452,12 @@ $config['extra_status_requested'] = FALSE;
 //Set this value to TRUE if you want to allow manager to create leave requests in behalf of their collaborators
 $config['requests_by_manager'] = TRUE;
 
+//____________________________________________________________________________
+//Set this value to TRUE if you want to allow manager to see the collaborators of the collaboratos
+//By default only the immediate collaborators (direct reports) are shown
+//(beware that it will impact the performance setting this to TRUE)
+$config['manager_sees_multiple_level_collaborators'] = FALSE;
+
 //Set this value to true if you want to force the manager to comment rejections
 $config['mandatory_comment_on_reject'] = FALSE;
 
@@ -480,7 +486,7 @@ $config['fonts'] =
 //____________________________________________________________________________
 // Hide/Disable features
 $config['disable_overtime'] = FALSE; //Set this value to TRUE if you want to hide the menu entries related to overtime
-$config['hide_global_cals_to_users'] = FALSE; //Set this value to TRUE if you want to hide global calendars (global/tabular) to users
+$config['hide_global_cals_to_users'] = TRUE; //Set this value to TRUE if you want to hide global calendars (global/tabular) to users
 $config['disable_department_calendar'] = FALSE; //Set this value to TRUE in order to disable the menu entry 'departement'
 $config['disable_workmates_calendar'] = FALSE; //Set this value to TRUE in order to disable the menu entry 'my workmates'
 


### PR DESCRIPTION
See #264

## What is the version of Jorani?

0.6.5

## Expected behavior

In the case of more than one level of reporters, allow the top manager to see the vacations of
the different levels (direct and nondirect reports)

## Example:
Manager1:

    Submanager1:
        collaborator1
        collaborator2
    Submanager2:
        collaborator3

The Manager 1 can see the vacations of the direct reports (first level of collaborators), but not lower levels

It would be handy to allow to see in the Approval->My subordinates, or in the Calendars->My subordinates the different levels.

Ideally this could be triggered by a config flag in config.php (in large organization this could be not viable)

//Set this value to TRUE if you want to allow manager to see the collaborators of the collaboratos
//By default only the immediate collaborators (direct reports) are shown
//(beware that it will impact the performance setting this to TRUE)
$config['manager_sees_multiple_level_collaborators'] = FALSE;

## Actual behavior

Only one level of the collaborators are shown.

## Steps to reproduce the behavior