### PR TITLE
Fix ical

### DIFF
--- a/application/controllers/Ics.php
+++ b/application/controllers/Ics.php
@@ -69,8 +69,10 @@ class Ics extends CI_Controller {
 
 
     /**
-     * Returns a VTIMEZONE component for a Olson timezone identifier
+     * Returns a VTIMEZONE component
      * with daylight transitions covering the given date range.
+     *
+     * Copied from: https://gist.github.com/thomascube/47ff7d530244c669825736b10877a200
      *
      * @param string Timezone ID as used in PHP's Date functions
      * @param integer Unix timestamp with first date/time in this timezone
@@ -79,7 +81,7 @@ class Ics extends CI_Controller {
      * @return mixed A Sabre\VObject\Component object representing a VTIMEZONE definition
      *               or false if no timezone information is available
      */
-    function generate_vtimezone($tzid, $from = 0, $to = 0)
+    function add_vtimezone($vcalendar, $tzid, $from = 0, $to = 0)
     {
         if (!$from) $from = time();
         if (!$to)   $to = $from;
@@ -95,7 +97,6 @@ class Ics extends CI_Controller {
         $year = 86400 * 360;
         $transitions = $tz->getTransitions($from - $year, $to + $year);
 
-        $vcalendar = new VObject\Component\VCalendar();
         $vt = $vcalendar->createComponent('VTIMEZONE');
         $vt->TZID = $tz->getName();
 
@@ -152,7 +153,7 @@ class Ics extends CI_Controller {
             $vt->add('X-MICROSOFT-CDO-TZID', $microsoftExchangeMap[$tz->getName()]);
         }
 
-        return $vt;
+        return $vcalendar->add($vt);
     }
 
     private function isFullDayEntry($leave) {
@@ -284,8 +285,7 @@ class Ics extends CI_Controller {
                 }
             }
 
-            $vtimezone = $this->generate_vtimezone($this->timezone);
-            $vcalendar->add($vtimezone);
+            $this->add_vtimezone($vcalendar, $this->timezone);
 
             echo $vcalendar->serialize();
         }
@@ -319,8 +319,7 @@ class Ics extends CI_Controller {
                 }
             }
 
-            $vtimezone = $this->generate_vtimezone($this->timezone);
-            $vcalendar->add($vtimezone);
+            $this->add_vtimezone($vcalendar, $this->timezone);
 
             echo $vcalendar->serialize();
         }
@@ -352,8 +351,7 @@ class Ics extends CI_Controller {
                 }
             }
 
-            $vtimezone = $this->generate_vtimezone($this->timezone);
-            $vcalendar->add($vtimezone);
+            $this->add_vtimezone($vcalendar, $this->timezone);
 
             echo $vcalendar->serialize();
         }
@@ -377,8 +375,7 @@ class Ics extends CI_Controller {
         $vcalendar = new VObject\Component\VCalendar();
         $vcalendar->add($vevent);
 
-        $vtimezone = $this->generate_vtimezone($this->timezone);
-        $vcalendar->add($vtimezone);
+        $this->add_vtimezone($vcalendar, $this->timezone);
 
         echo $vcalendar->serialize();
     }

--- a/application/controllers/Ics.php
+++ b/application/controllers/Ics.php
@@ -165,8 +165,7 @@ class Ics extends CI_Controller {
         return TRUE;
     }
 
-    private function createVEvent($leave) {
-        $vcalendar = new VObject\Component\VCalendar();
+    private function createVEvent($vcalendar, $leave) {
         $vevent = $vcalendar->createComponent('VEVENT');
 
         $vevent->CATEGORIES = lang('leave');
@@ -277,7 +276,7 @@ class Ics extends CI_Controller {
             $vcalendar = new VObject\Component\VCalendar();
             foreach ($result as $leave) {
                 if (($leave['status'] != LMS_CANCELED) && ($leave['status'] != LMS_REJECTED)) {
-                    $vevent = $this->createVEvent($leave);
+                    $vevent = $this->createVEvent($vcalendar, $leave);
                     $vevent->SUMMARY = lang('leave');
                     $vevent->DESCRIPTION = $leave['cause'];
 
@@ -311,7 +310,7 @@ class Ics extends CI_Controller {
             $vcalendar = new VObject\Component\VCalendar();
             foreach ($result as $leave) {
                 if (($leave['status'] != LMS_CANCELED) && ($leave['status'] != LMS_REJECTED)) {
-                    $vevent = $this->createVEvent($leave);
+                    $vevent = $this->createVEvent($vcalendar, $leave);
                     $vevent->SUMMARY = $leave['firstname'] . ' ' . $leave['lastname'];
                     $vevent->DESCRIPTION = $leave['type'] . ($leave['cause']!=''?(' / ' . $leave['cause']):'');
 
@@ -342,7 +341,7 @@ class Ics extends CI_Controller {
             $vcalendar = new VObject\Component\VCalendar();
             foreach ($result as $leave) {
                 if (($leave['status'] != LMS_CANCELED) && ($leave['status'] != LMS_REJECTED)) {
-                    $vevent = $this->createVEvent($leave);
+                    $vevent = $this->createVEvent($vcalendar, $leave);
                     $vevent->SUMMARY = $leave['firstname'] . ' ' . $leave['lastname'];
                     $vevent->DESCRIPTION = $leave['type_label'] . ($leave['cause']!=''?(' / ' . $leave['cause']):'');
 
@@ -370,9 +369,9 @@ class Ics extends CI_Controller {
         //Get timezone and language of the user
         $this->getTimezoneAndLanguageOfUser($leave['employee']);
 
-        $vevent = $this->createVEvent($leave);
-
         $vcalendar = new VObject\Component\VCalendar();
+
+        $vevent = $this->createVEvent($vcalendar, $leave);
         $vcalendar->add($vevent);
 
         $this->add_vtimezone($vcalendar, $this->timezone);

--- a/application/controllers/Ics.php
+++ b/application/controllers/Ics.php
@@ -345,7 +345,6 @@ class Ics extends CI_Controller {
                     $vevent->SUMMARY = $leave['firstname'] . ' ' . $leave['lastname'];
                     $vevent->DESCRIPTION = $leave['type_label'] . ($leave['cause']!=''?(' / ' . $leave['cause']):'');
 
-                    $vcalendar = new VObject\Component\VCalendar();
                     $vcalendar->add($vevent);
                 }
             }

--- a/application/controllers/Ics.php
+++ b/application/controllers/Ics.php
@@ -81,7 +81,7 @@ class Ics extends CI_Controller {
      * @return mixed A Sabre\VObject\Component object representing a VTIMEZONE definition
      *               or false if no timezone information is available
      */
-    function add_vtimezone($vcalendar, $tzid, $from = 0, $to = 0)
+    private function addVTimezone($vcalendar, $tzid, $from = 0, $to = 0)
     {
         if (!$from) $from = time();
         if (!$to)   $to = $from;
@@ -284,7 +284,7 @@ class Ics extends CI_Controller {
                 }
             }
 
-            $this->add_vtimezone($vcalendar, $this->timezone);
+            $this->addVTimezone($vcalendar, $this->timezone);
 
             echo $vcalendar->serialize();
         }
@@ -318,7 +318,7 @@ class Ics extends CI_Controller {
                 }
             }
 
-            $this->add_vtimezone($vcalendar, $this->timezone);
+            $this->addVTimezone($vcalendar, $this->timezone);
 
             echo $vcalendar->serialize();
         }
@@ -350,7 +350,7 @@ class Ics extends CI_Controller {
                 }
             }
 
-            $this->add_vtimezone($vcalendar, $this->timezone);
+            $this->addVTimezone($vcalendar, $this->timezone);
 
             echo $vcalendar->serialize();
         }
@@ -374,7 +374,7 @@ class Ics extends CI_Controller {
         $vevent = $this->createVEvent($vcalendar, $leave);
         $vcalendar->add($vevent);
 
-        $this->add_vtimezone($vcalendar, $this->timezone);
+        $this->addVTimezone($vcalendar, $this->timezone);
 
         echo $vcalendar->serialize();
     }


### PR DESCRIPTION
This MR is changing the way how 'full day' leaves are represented in ICS calendars.

Instead of "hardcoded" 0:00→23:59 duration, now DTSTART & DTEND fields can use Date (instead of DateTime) notation which gives ical clients possibility to show events/leaves as 'full day' event.

Here you can see the difference

**Old visualization**

![image](https://user-images.githubusercontent.com/317231/115154397-e4cc9880-a07a-11eb-9869-897bb2c9148c.png)

**New visualization**

![image](https://user-images.githubusercontent.com/317231/115154421-15accd80-a07b-11eb-84f0-d24bb36a0862.png)

This original visualization was (at least for me) extremely annoying. When I wanted to mix two types of calendars: one with my appointments and second with all leaves in my company (so 'global' or 'my subordinates' calendar) generated view was like this

![image](https://user-images.githubusercontent.com/317231/115154876-67eeee00-a07d-11eb-8611-386625537938.png)

In case when more than one coworker was listed situation was even worst. 

**About VTIMEZONE**

ICS content returned by jorani to the clients were tested by my on https://icalendar.org/validator.html page and this validator complains about missing VTIMEZONE entries. Therefore, this ICAL element were added as well. 
This part of code was borrowed from https://gist.github.com/thomascube/47ff7d530244c669825736b10877a200 and only slightly aligned with the rest of jorani software.