### PR TITLE
PHP 8.2 Fix

### DIFF
--- a/application/libraries/MY_Email.php
+++ b/application/libraries/MY_Email.php
@@ -111,7 +111,7 @@ class MY_Email extends CI_Email {
 
     public function __destruct() {
 
-        if (is_callable('parent::__destruct')) {
+        if (is_callable('parent', '__destruct')) {
             parent::__destruct();
         }
     }

--- a/application/models/Leaves_model.php
+++ b/application/models/Leaves_model.php
@@ -679,7 +679,8 @@ class Leaves_model extends CI_Model {
         if (isset($json_parsed)){
           array_push($json_parsed->comments, $commentObject);
         }else {
-          $json_parsed->comments = array($commentObject);
+            $json_parsed = new stdClass;
+            $json_parsed->comments = array($commentObject);
         }
         $comment_change = new stdClass;
         $comment_change->type = "change";


### PR DESCRIPTION
Issue https://github.com/bbalet/jorani/issues/395
Bug fixed by wrigjz

is_callable('parent::XXXX') crash in php 8.2
https://php.watch/versions/8.2/partially-supported-callable-deprecation
